### PR TITLE
Derivation path configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /lib/
 /node_modules/
+.idea

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ engine.start();
 web3.eth.getAccounts(console.log);
 ```
 
+To change derivation path that will be used to derive private/public keys on your nano, modify snippet above as follows
+
+```
+var derivation_path = "44'/60'/103'/0'";
+var ledgerWalletSubProvider = async LedgerWalletSubproviderFactory(derivation_path);
+```
+
+All paths must start with `44'/60'` or `44'/61'`.
+
 **Note:** In order to send requests to the Ledger wallet, the user must have done the following:
 - Plugged-in their Ledger Wallet Nano S
 - Input their 4 digit pin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledger-wallet-provider",
-  "version": "1.14.19",
+  "version": "1.15.4",
   "description": "Ledger Nano S wallet provider for the Web3 ProviderEngine",
   "main": "lib/index.js",
   "scripts": {

--- a/src/LedgerWallet.js
+++ b/src/LedgerWallet.js
@@ -37,9 +37,15 @@ const NOT_SUPPORTED_ERROR_MSG =
  *  https://github.com/MetaMask/metamask-plugin/blob/master/app/scripts/keyrings/hd.js
  *
  */
+const allowed_hd_paths = ["44'/60'", "44'/61'"];
+
 class LedgerWallet {
-    constructor() {
-        this._path = "44'/60'/0'/0";
+
+    constructor(path) {
+        path = path || allowed_hd_paths[0];
+        if (!allowed_hd_paths.some(hd_pref => path.startsWith(hd_pref)))
+            throw new Error(`hd derivation path for Nano Ledger S may only start [${allowed_hd_paths}], ${path} was provided`);
+        this._path = path;
         this._accounts = null;
         this.isU2FSupported = null;
         this.getAppConfig = this.getAppConfig.bind(this);

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,8 @@
 import HookedWalletSubprovider from "web3-provider-engine/subproviders/hooked-wallet.js";
 import LedgerWallet from "./LedgerWallet";
 
-
-export default async function () {
-    const ledger = new LedgerWallet();
+export default async function (path_override) {
+    const ledger = new LedgerWallet(path_override);
     await ledger.init();
     const LedgerWalletSubprovider = new HookedWalletSubprovider(ledger);
 


### PR DESCRIPTION
Derivation paths may be used to separate key hierarchies for different d-apps. While you use the same nano ledger different key pairs are derived for different apps.

This pull requests allows to pass derivation path like this while initializing the provider:

```
var derivation_path = "44'/60'/103'/0'";
var ledgerWalletSubProvider = async LedgerWalletSubproviderFactory(derivation_path);
```